### PR TITLE
no-param-reassign now ignores object prop assignments

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,5 +21,6 @@ module.exports = {
     'object-curly-newline': 'off',
     'quote-props': ['error', 'consistent-as-needed'],
     'space-before-function-paren': 'warn',
+    'no-param-reassign': ['error', { props: false }],
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecosia/eslint-config",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Ecosia shareable ESLint config ✅",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This should help us get rid of all those manual `disable`s in Vuex stores.